### PR TITLE
fix lint errors and remove the logger

### DIFF
--- a/ruler.go
+++ b/ruler.go
@@ -2,13 +2,10 @@ package ruler
 
 import (
 	"encoding/json"
-	"github.com/tj/go-debug"
 	"reflect"
 	"regexp"
 	"strings"
 )
-
-var ruleDebug = debug.Debug("ruler:rule")
 
 // we'll use these values
 // to avoid passing strings to our
@@ -28,11 +25,12 @@ const (
 	ncontains = iota
 )
 
+// Ruler defines multiple rules
 type Ruler struct {
 	rules []*Rule
 }
 
-// creates a new Ruler for you
+// NewRuler creates a new Ruler for you
 // optionally accepts a pointer to a slice of filters
 // if you have filters that you want to start with
 func NewRuler(rules []*Rule) *Ruler {
@@ -45,9 +43,9 @@ func NewRuler(rules []*Rule) *Ruler {
 	return &Ruler{}
 }
 
-// returns a new ruler with filters parsed from JSON data
+// NewRulerWithJSON returns a new ruler with filters parsed from JSON data
 // expects JSON as a slice of bytes and will parse your JSON for you!
-func NewRulerWithJson(jsonstr []byte) (*Ruler, error) {
+func NewRulerWithJSON(jsonstr []byte) (*Ruler, error) {
 	var rules []*Rule
 
 	err := json.Unmarshal(jsonstr, &rules)
@@ -58,7 +56,7 @@ func NewRulerWithJson(jsonstr []byte) (*Ruler, error) {
 	return NewRuler(rules), nil
 }
 
-// adds a new rule for the property at `path`
+// Rule adds a new rule for the property at `path`
 // returns a RulerFilter that you can use to add conditions
 // and more filters
 func (r *Ruler) Rule(path string) *RulerRule {
@@ -76,7 +74,7 @@ func (r *Ruler) Rule(path string) *RulerRule {
 	}
 }
 
-// tests all the rules (i.e. filters) in your set of rules,
+// Test tests all the rules (i.e. filters) in your set of rules,
 // given a map that looks like a JSON object
 // (map[string]interface{})
 func (r *Ruler) Test(o map[string]interface{}) bool {
@@ -99,7 +97,6 @@ func (r *Ruler) Test(o map[string]interface{}) bool {
 			// either one of these can be done
 			return r.compare(f, val)
 		} else {
-			ruleDebug("did not find property (%s) on map", f.Path)
 			// if we couldn't find the value on the map
 			// and the comparator isn't exists/nexists, this fails
 			return false
@@ -112,7 +109,6 @@ func (r *Ruler) Test(o map[string]interface{}) bool {
 
 // compares real v. actual values
 func (r *Ruler) compare(f *Rule, actual interface{}) bool {
-	ruleDebug("beginning comparison")
 	expected := f.Value
 	switch f.Comparator {
 	case "eq":
@@ -153,7 +149,6 @@ func (r *Ruler) compare(f *Rule, actual interface{}) bool {
 		//should probably return an error or something
 		//but this is good for now
 		//if comparator is not implemented, return false
-		ruleDebug("unknown comparator %s", f.Comparator)
 		return false
 	}
 }
@@ -164,7 +159,6 @@ func (r *Ruler) compare(f *Rule, actual interface{}) bool {
 // and some other acrobatics
 func (r *Ruler) inequality(op int, actual, expected interface{}) bool {
 	// need some variables for these deals
-	ruleDebug("entered inequality comparison")
 	var cmpStr [2]string
 	var cmpUint [2]uint64
 	var cmpInt [2]int64
@@ -199,7 +193,6 @@ func (r *Ruler) inequality(op int, actual, expected interface{}) bool {
 		case string:
 			cmpStr[idx] = t
 		default:
-			ruleDebug("invalid type for inequality comparison")
 			return false
 		}
 	}
@@ -233,24 +226,20 @@ func (r *Ruler) inequality(op int, actual, expected interface{}) bool {
 }
 
 func (r *Ruler) regexp(actual, expected interface{}) bool {
-	ruleDebug("beginning regexp")
 	// regexps must be strings
 	var streg string
 	var ok bool
 	if streg, ok = expected.(string); !ok {
-		ruleDebug("expected value not actually a string, bailing")
 		return false
 	}
 
 	var astring string
 	if astring, ok = actual.(string); !ok {
-		ruleDebug("actual value not actually a string, bailing")
 		return false
 	}
 
 	reg, err := regexp.Compile(streg)
 	if err != nil {
-		ruleDebug("regexp is bad, bailing")
 		return false
 	}
 
@@ -274,7 +263,7 @@ func pluck(o map[string]interface{}, path string) interface{} {
 			return nil
 		}
 
-		for i := 1; i < len(parts)-1; i += 1 {
+		for i := 1; i < len(parts)-1; i++ {
 			// we need to check the existence of another
 			// map[string]interface for every property along the way
 			cp := parts[i]
@@ -291,9 +280,9 @@ func pluck(o map[string]interface{}, path string) interface{} {
 
 		if prev[parts[len(parts)-1]] != nil {
 			return prev[parts[len(parts)-1]]
-		} else {
-			return nil
 		}
+
+		return nil
 	}
 
 	return nil

--- a/ruler_test.go
+++ b/ruler_test.go
@@ -246,7 +246,7 @@ func BenchmarkPluckShallow(b *testing.B) {
 		},
 	}
 
-	for i := 0; i < b.N; i += 1 {
+	for i := 0; i < b.N; i++ {
 		r := pluck(o, "hey.there")
 		if r != 4 {
 			b.Errorf("fail bench, val was %s", r)
@@ -273,7 +273,7 @@ func BenchmarkPluckDeep(b *testing.B) {
 		},
 	}
 
-	for i := 0; i < b.N; i += 1 {
+	for i := 0; i < b.N; i++ {
 		r := pluck(o, "test.thing.here.today.is.awesome.with.thestuff")
 		if r != "no dice" {
 			b.Errorf("fail bench, val was %s", r)
@@ -281,13 +281,13 @@ func BenchmarkPluckDeep(b *testing.B) {
 	}
 }
 
-func TestNewRulerWithJson(t *testing.T) {
-	theJson := []byte(`[
+func TestNewRulerWithJSON(t *testing.T) {
+	theJSON := []byte(`[
 			{"comparator": "eq", "path": "name", "value": "Thomas"}
 		]
 	`)
 
-	r, err := NewRulerWithJson(theJson)
+	r, err := NewRulerWithJSON(theJSON)
 	if err != nil {
 		t.Errorf("Error getting new ruler w/json: %s", err)
 	}
@@ -297,12 +297,12 @@ func TestNewRulerWithJson(t *testing.T) {
 	}
 
 	if !r.Test(data) {
-		t.Error("newRulerWithJson didn't do something properly!")
+		t.Error("newRulerWithJSON didn't do something properly!")
 	}
 }
 
-func BenchmarkNewRulerWithJson(b *testing.B) {
-	theJson := []byte(`[
+func BenchmarkNewRulerWithJSON(b *testing.B) {
+	theJSON := []byte(`[
 			{"comparator": "eq", "path": "name", "value": "Thomas"}
 		]
 	`)
@@ -310,14 +310,14 @@ func BenchmarkNewRulerWithJson(b *testing.B) {
 		"name": "Thomas",
 	}
 
-	for i := 0; i < b.N; i += 1 {
-		r, err := NewRulerWithJson(theJson)
+	for i := 0; i < b.N; i++ {
+		r, err := NewRulerWithJSON(theJSON)
 		if err != nil {
 			b.Errorf("Error getting new ruler w/json: %s", err)
 		}
 
 		if !r.Test(data) {
-			b.Error("newRulerWithJson didn't do something properly!")
+			b.Error("newRulerWithJSON didn't do something properly!")
 		}
 	}
 }
@@ -335,7 +335,7 @@ func BenchmarkNewRulerWithRulesSimple(b *testing.B) {
 		"name": "Bob",
 	}
 
-	for i := 0; i < b.N; i += 1 {
+	for i := 0; i < b.N; i++ {
 		r := NewRuler(filters)
 
 		if !r.Test(data) {
@@ -423,7 +423,7 @@ func BenchmarkNewRulerWithRulesTen(b *testing.B) {
 		},
 	}
 
-	for i := 0; i < b.N; i += 1 {
+	for i := 0; i < b.N; i++ {
 		r := NewRuler(filters)
 
 		if !r.Test(data) {


### PR DESCRIPTION
Fix standard lint warnings and remove the logger because the logger repository was deleted by its author